### PR TITLE
Corrected an iPad keyboard hiding issue.

### DIFF
--- a/src/KKPasscodeViewController.h
+++ b/src/KKPasscodeViewController.h
@@ -106,6 +106,10 @@ typedef NSUInteger KKPasscodeMode;
 
   // whatever the erase data option is turned on or off
   BOOL _eraseData;
+    
+    // Used to make sure we do not release the keyboard when on iPad
+    BOOL _shouldReleaseFirstResponser;
+
 }
 
 @property (nonatomic, unsafe_unretained) id <KKPasscodeViewControllerDelegate> delegate; 

--- a/src/KKPasscodeViewController.m
+++ b/src/KKPasscodeViewController.m
@@ -23,7 +23,7 @@
 #import <QuartzCore/QuartzCore.h>
 #import <AudioToolbox/AudioToolbox.h>
 
-@interface KKPasscodeViewController(Private)
+@interface KKPasscodeViewController (Private)
 
 - (UITextField*)passcodeTextField;
 - (NSArray*)boxes;
@@ -72,6 +72,9 @@
 	_confirmPasscodeTableView.separatorStyle = UITableViewCellSeparatorStyleNone;
 	_confirmPasscodeTableView.backgroundColor = [UIColor groupTableViewBackgroundColor];
 	[self.view addSubview:_confirmPasscodeTableView];
+    
+    _shouldReleaseFirstResponser = NO;
+
 }
 
 
@@ -206,7 +209,14 @@
 }
 
 
-
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    
+    _shouldReleaseFirstResponser = YES;
+    [_enterPasscodeTextField resignFirstResponder];
+    [_setPasscodeTextField resignFirstResponder];
+    [_confirmPasscodeTextField resignFirstResponder];
+}
 
 
 #pragma mark -
@@ -287,8 +297,9 @@
 	newTableView.frame = self.view.frame;
 	[UIView commitAnimations];
 	
-	
+	_shouldReleaseFirstResponser = YES;
 	[[_textFields objectAtIndex:_currentPanel - 1] resignFirstResponder];
+	_shouldReleaseFirstResponser = NO;
 	[[_textFields objectAtIndex:_currentPanel] becomeFirstResponder];
 }
 
@@ -311,7 +322,9 @@
 	newTableView.frame = self.view.frame;
 	[UIView commitAnimations];
 	
+    _shouldReleaseFirstResponser = YES;
 	[[_textFields objectAtIndex:_currentPanel + 1] resignFirstResponder];
+    _shouldReleaseFirstResponser = NO;
 	[[_textFields objectAtIndex:_currentPanel] becomeFirstResponder];
 }
 
@@ -657,6 +670,9 @@
 
 
 
+- (BOOL)textFieldShouldEndEditing:(UITextField *)textField {
+    return _shouldReleaseFirstResponser;
+}
 
 #pragma mark -
 #pragma mark Memory management


### PR DESCRIPTION
I corrected a minor issue for iPad users, when they try to hide the keyboard. The solution I implemented was to not allow the user to hide the keyboard until they entered a correct passcode or cancelled the viewcontroller.

By the way, great implementation of the passcodelock!
