### PR TITLE
KKPasscodeSettingsViewControllerDelegate:passcodeLockWillBePresented

### DIFF
--- a/src/KKPasscodeSettingsViewController.h
+++ b/src/KKPasscodeSettingsViewController.h
@@ -29,6 +29,11 @@
  */
 - (void)didSettingsChanged:(KKPasscodeSettingsViewController*)viewController;
 
+/**
+ * called when the passcode lock dialog will be presented
+ */
+- (void)passcodeLockWillBePresented;
+
 @end
 
 @interface KKPasscodeSettingsViewController : UITableViewController <UIActionSheetDelegate, KKPasscodeViewControllerDelegate> {

--- a/src/KKPasscodeSettingsViewController.m
+++ b/src/KKPasscodeSettingsViewController.m
@@ -187,10 +187,10 @@
 			nav.navigationBar.barStyle = self.navigationController.navigationBar.barStyle;		
 		}
 		
-		[self.delegate passcodeLockWillBePresented];
-    
+		if ([self.delegate respondsToSelector:@selector(passcodeLockWillBePresented)]) {
+		  [self.delegate passcodeLockWillBePresented];
+	  }
 		[self.navigationController presentModalViewController:nav animated:YES];
-		
 		
 	} else if (indexPath.section == 1 && _passcodeLockOn) {
 		KKPasscodeViewController *vc = [[KKPasscodeViewController alloc] initWithNibName:nil bundle:nil];
@@ -212,8 +212,9 @@
 			nav.navigationBar.barStyle = self.navigationController.navigationBar.barStyle;		
 		}
 		
-		[self.delegate passcodeLockWillBePresented];
-    
+		if ([self.delegate respondsToSelector:@selector(passcodeLockWillBePresented)]) {
+		  [self.delegate passcodeLockWillBePresented];
+	  }
 		[self.navigationController presentModalViewController:nav animated:YES];
 	}
 	[tableView deselectRowAtIndexPath:indexPath animated:YES];

--- a/src/KKPasscodeSettingsViewController.m
+++ b/src/KKPasscodeSettingsViewController.m
@@ -187,6 +187,8 @@
 			nav.navigationBar.barStyle = self.navigationController.navigationBar.barStyle;		
 		}
 		
+		[self.delegate passcodeLockWillBePresented];
+    
 		[self.navigationController presentModalViewController:nav animated:YES];
 		
 		
@@ -210,9 +212,11 @@
 			nav.navigationBar.barStyle = self.navigationController.navigationBar.barStyle;		
 		}
 		
-		[self.navigationController presentModalViewController:nav animated:YES];	
-    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+		[self.delegate passcodeLockWillBePresented];
+    
+		[self.navigationController presentModalViewController:nav animated:YES];
 	}
+	[tableView deselectRowAtIndexPath:indexPath animated:YES];
 }
 
 - (void)didSettingsChanged:(KKPasscodeViewController*)viewController 

--- a/src/KKPasscodeViewController.m
+++ b/src/KKPasscodeViewController.m
@@ -43,6 +43,11 @@
 #pragma mark -
 #pragma mark UIViewController
 
+- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
+{
+  return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad;
+}
+
 - (void)loadView
 {
 	[super loadView];


### PR DESCRIPTION
I've added an optional method to KKPasscodeSettingsViewControllerDelegate, in order to notify the delegate that the passcode lock view will be on screen. The reason is to allow things like dismissing a popover controller. Additionally, I've unlocked rotation for the passcode view while on iPad.
